### PR TITLE
Fix persistence of analysis job data products

### DIFF
--- a/harnessed_jobs/collect_raft_results/v0/producer_collect_raft_results.py
+++ b/harnessed_jobs/collect_raft_results/v0/producer_collect_raft_results.py
@@ -115,5 +115,5 @@ bar_charts.make_bar_chart('PSF_SIGMA', 'PSF sigma (microns)', spec=5.,
 plt.savefig('%s_psf_sigma.png' % raft_id)
 
 bar_charts.make_multi_bar_chart(('GAIN', 'PTC_GAIN'), 'System Gain (e-/ADU)',
-                                title=raft_id, colors='br')
+                                title=raft_id, colors='br', ylog=True)
 plt.savefig('%s_system_gain.png' % raft_id)

--- a/harnessed_jobs/fe55_raft_analysis/v0/validator_fe55_raft_analysis.py
+++ b/harnessed_jobs/fe55_raft_analysis/v0/validator_fe55_raft_analysis.py
@@ -59,6 +59,8 @@ for slot, sensor_id in raft.items():
                                           slot=slot,
                                           sensor_id=sensor_id))
 
+    results.extend([lcatr.schema.fileref.make(x) for x in output_files])
+
 results.extend(siteUtils.jobInfo())
 lcatr.schema.write_file(results)
 lcatr.schema.validate_file()

--- a/harnessed_jobs/prnu_raft/v0/validator_prnu_raft.py
+++ b/harnessed_jobs/prnu_raft/v0/validator_prnu_raft.py
@@ -27,7 +27,7 @@ for slot, sensor_id in raft.items():
 
         qe_acq_job_id = \
             siteUtils.get_prerequisite_job_id('S*/%s_lambda_flat_*.fits' % sensor_id,
-                                              jobname='qe_raft_acq_sim')
+                                              jobname=siteUtils.getProcessName('qe_raft_acq'))
         md = dict(illumination_non_uniformity_file=dict(JOB_ID=qe_acq_job_id))
         results.extend(eotestUtils.eotestCalibsPersist('illumination_non_uniformity_file',
                                                        metadata=md))

--- a/harnessed_jobs/qe_raft_analysis/v0/validator_qe_raft_analysis.py
+++ b/harnessed_jobs/qe_raft_analysis/v0/validator_qe_raft_analysis.py
@@ -30,7 +30,7 @@ for slot, sensor_id in raft.items():
                                           band=band, QE=np.mean(QE[band]),
                                           slot=slot, sensor_id=sensor_id))
 
-    qe_files = glob.glob('*QE*.*')
+    qe_files = glob.glob('%s_*QE*.*' % sensor_id)
     for item in qe_files:
         if item.endswith('.fits'):
             eotestUtils.addHeaderData(item, LSST_NUM=sensor_id,

--- a/harnessed_jobs/qe_raft_analysis/v0/validator_qe_raft_analysis.py
+++ b/harnessed_jobs/qe_raft_analysis/v0/validator_qe_raft_analysis.py
@@ -49,7 +49,7 @@ for slot, sensor_id in raft.items():
 sensor_id = raft.sensor_names[0]
 qe_acq_job_id = siteUtils.get_prerequisite_job_id(('S*/%s_lambda_flat_*.fits'
                                                    % sensor_id),
-                                                  jobname='qe_raft_acq_sim')
+                                                  jobname=siteUtils.getProcessName('qe_raft_acq'))
 md = dict(photodiode_ratio_file=dict(JOB_ID=qe_acq_job_id),
           illumination_non_uniformity_file=dict(JOB_ID=qe_acq_job_id))
 

--- a/harnessed_jobs/read_noise_raft/v0/validator_read_noise_raft.py
+++ b/harnessed_jobs/read_noise_raft/v0/validator_read_noise_raft.py
@@ -33,7 +33,7 @@ for slot, sensor_id in raft.items():
                                           sensor_id=sensor_id))
 
     fe55_acq_job_id = siteUtils.get_prerequisite_job_id('S*/%s_fe55_fe55_*.fits' % sensor_id,
-                                                        jobname='fe55_raft_acq_sim')
+                                                        jobname=siteUtils.getProcessName('fe55_raft_acq'))
 
     files = glob.glob('%s_read_noise?*.fits' % sensor_id)
     for fitsfile in files:


### PR DESCRIPTION
- psf catalogs in fe55_raft_analysis
- avoid duplicate files in qe_raft_analysis
- use `siteUtils.getProcessName` in read_noise_raft, qe_raft_analysis, and prnu_raft